### PR TITLE
Fix outdated url

### DIFF
--- a/src/professors.ts
+++ b/src/professors.ts
@@ -38,4 +38,4 @@ export const getProfessorRatings = async () => {
 };
 
 // returns link to professor's rating page
-export const getProfLink = (prof: Teacher): string => `https://polyratings.dev/teacher/${prof.id}`;
+export const getProfLink = (prof: Teacher): string => `https://polyratings.dev/professor/${prof.id}`;


### PR DESCRIPTION
I noticed when using the extension I got directed to the wrong URL. We deprecated the /teacher in favor of /professor some time ago but have recently removed it from the website.